### PR TITLE
Fix python version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We now use python 3.9 so the CI does not error out